### PR TITLE
Pass error into payment failed callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/sequra"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A library to integrate the Mufasa iframe",
   "main": "dist/index.js",
   "types": "src/types.d.ts",

--- a/src/paymentForm.ts
+++ b/src/paymentForm.ts
@@ -46,7 +46,7 @@ const paymentForm = ({
           break;
         }
         case 'Sequra.payment_failed': {
-          onPaymentFailed();
+          onPaymentFailed({ error: eventData.error });
           break;
         }
         case 'Sequra.payment_successful': {

--- a/src/tests/iframePages/onPaymentFailed.html
+++ b/src/tests/iframePages/onPaymentFailed.html
@@ -2,7 +2,7 @@
 <html>
 <body>
 <script>
-  window.parent.postMessage(JSON.stringify({ action: 'Sequra.payment_failed' }), '*')
+  window.parent.postMessage(JSON.stringify({ action: 'Sequra.payment_failed', error: 'authentication' }), '*')
 </script>
 </body>
 </html>

--- a/src/tests/sequraPCI.test.ts
+++ b/src/tests/sequraPCI.test.ts
@@ -22,12 +22,11 @@ describe('SequraPCI', () => {
     });
   });
 
-  describe('callbacks', () => {
+  describe('callbacks without params', () => {
     const callbackNames = [
       'onFormErrors',
       'onCardDataFulfilled',
       'onPaymentSuccessful',
-      'onPaymentFailed',
       'onFormSubmitted',
       'onScaLoaded',
       'onScaClosed',
@@ -52,7 +51,27 @@ describe('SequraPCI', () => {
         expect(callbackSpy).toHaveBeenCalledTimes(1);
       });
     });
-  })
+  });
+
+  describe('callback with params', () => {
+    test('onPaymentFailed', async () => {
+        const callbackSpy = jest.fn();
+        await new Promise((resolve) => {
+          const callback = ({ error }: { error: string }) => {
+            callbackSpy(error);
+            resolve(null);
+          };
+
+          paymentForm = SequraPCI.paymentForm({
+            url: `${basePath}/onPaymentFailed.html`,
+            onPaymentFailed: callback,
+          }).mount('my-container');
+
+          setTimeout(resolve, 500); // To not lock the test in case the callback is not called
+        });
+        expect(callbackSpy).toHaveBeenNthCalledWith(1, "authentication");
+    });
+  });
 
   test('#unbind removes event listeners', async () => {
     const onFormSubmitted = jest.fn();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,7 +8,7 @@ interface PaymentFormConfig {
   url: string;
   onCardDataFulfilled?: () => void;
   onFormErrors?: () => void;
-  onPaymentFailed?: () => void;
+  onPaymentFailed?: (data: { error: string }) => void;
   onPaymentSuccessful?: () => void;
   onFormSubmitted?: () => void;
   onScaRequired?: () => void;


### PR DESCRIPTION
`Sequra.payment_failed` post message now includes an `error` param detailing the type of error.
Pass this info into the `paymentFailed` callback.