### PR TITLE
Forward Sequra.3ds_authentication_loaded to the Mufasa iframe

### DIFF
--- a/src/paymentForm.ts
+++ b/src/paymentForm.ts
@@ -105,10 +105,12 @@ const paymentForm = ({
           if (scaIframe) {
             scaIframe.classList.remove('hidden');
           }
+          mufasaIframe.contentWindow.postMessage(JSON.stringify(eventData), url);
           onScaLoaded();
           break;
         case 'Sequra.3ds_authentication_closed':
           onScaClosed();
+          // falls through
         case 'Sequra.new_form_fields':
           // falls through
         case 'Sequra.start_synchronization_polling':

--- a/src/tests/iframePages/onScaRequired.html
+++ b/src/tests/iframePages/onScaRequired.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+  window.parent.postMessage(JSON.stringify({ action: 'Sequra.3ds_authentication', src: "https://www.example.com" }), '*')
+</script>
+</body>
+</html>


### PR DESCRIPTION
### What is the goal?

`Sequra.3ds_authentication_loaded` are not being tracked by Mufasa because the form are not receiving those events, just the host page receive them.

### How is it being implemented?

Forward the event just like `Sequra.new_form_fields` one

### Opportunistic refactorings

No

### Caveats

Missing tests were added

### How is it tested?

Automatic & manual

 ### How is it going to be distributed?

Standard distribution
