### PR TITLE
Change token form iframe visibility method

### DIFF
--- a/src/paymentForm.ts
+++ b/src/paymentForm.ts
@@ -37,10 +37,17 @@ const paymentForm = ({
       name: 'mufasa-iframe',
       src: url,
     });
+    const tokenFormStyles = !hidden ? {} : {
+      position: 'absolute',
+      height: '0px',
+      left: '-999px',
+      overflow: 'hidden',
+      opacity: '0',
+    };
     setElementStyles(mufasaIframe, {
       ...baseStyles,
       ...styles,
-      display: hidden ? 'none' : 'block'
+      ...tokenFormStyles,
     });
     if(className) {
       mufasaIframe.className = className;

--- a/src/tests/sequraPCI.test.ts
+++ b/src/tests/sequraPCI.test.ts
@@ -28,7 +28,13 @@ describe('SequraPCI', () => {
     test('mounts the iframe in the DOM, hidden', () => {
       paymentForm = SequraPCI.paymentForm({ url: emptyUrl }).mount('my-container', { hidden: true });
       const mufasaIframe = document.querySelector('iframe');
-      expect(mufasaIframe.style["display"]).toEqual("none");
+      expect(mufasaIframe).toHaveStyle({
+        position: 'absolute',
+        height: '0px',
+        left: '-999px',
+        overflow: 'hidden',
+        opacity: '0',
+      });
     });
 
     test('it uses custom styles', () => {


### PR DESCRIPTION
### What is the goal?

CKO risk.js library needed for https://sequra.atlassian.net/browse/MUF-655 doesn't work if rendered inside an iframe that is `display: none`, so the iframe need to be hidden in a different way.

### References
* **Related pull-requests:** https://github.com/sequra/mufasa/pull/1221

### How is it being implemented?

Replace `display: none` with off-the viewport styles.

### Opportunistic refactorings

No

### Caveats

No

### Does it affect (changes or update) any sensitive data?

_Check [Sensitive data list documentation](../blob/master/docs/sensitive_data/README.md) and [Sensitive data list](../blob/master/docs/sensitive_data/sensitive-data.yml)

### How is it tested?

Automatic tests

 ### How is it going to be distributed?

Standard distribution
