### PR TITLE
Use Sequra.form_loaded PostMessage to fire onLoad callback

### DIFF
--- a/src/paymentForm.ts
+++ b/src/paymentForm.ts
@@ -63,31 +63,25 @@ const paymentForm = ({
       }
 
       switch (eventData.action) {
-        case 'Sequra.invalid_form': {
+        case 'Sequra.invalid_form':
           onFormErrors();
           break;
-        }
-        case 'Sequra.card_data_fulfilled': {
+        case 'Sequra.card_data_fulfilled':
           onCardDataFulfilled();
           break;
-        }
-        case 'Sequra.payment_failed': {
+        case 'Sequra.payment_failed':
           onPaymentFailed({ error: eventData.error });
           break;
-        }
-        case 'Sequra.payment_successful': {
+        case 'Sequra.payment_successful':
           onPaymentSuccessful();
           break;
-        }
-        case 'Sequra.mufasa_submitted': {
+        case 'Sequra.mufasa_submitted':
           onFormSubmitted();
           break;
-        }
-        case 'Sequra.mufasa_resized': {
+        case 'Sequra.mufasa_resized':
           setElementStyles(mufasaIframe, { height: `${eventData.height}px`});
           break;
-        }
-        case 'Sequra.3ds_authentication': {
+        case 'Sequra.3ds_authentication':
           scaWrapper = createElement('div', {
             id: 'iframe-3ds-autentication-wrapper',
             style: 'display:block;position:fixed;z-index:2147483647;top:0;left:0;right:0;bottom:0;',
@@ -107,7 +101,9 @@ const paymentForm = ({
           document.body.appendChild(scaWrapper);
           onScaRequired();
           break;
-        }
+        case 'Sequra.form_loaded':
+          onLoad();
+          break;
         case 'Sequra.3ds_authentication_loaded':
           if (scaIframe) {
             scaIframe.classList.remove('hidden');
@@ -129,8 +125,6 @@ const paymentForm = ({
     };
     listenPostMessages(eventListener);
 
-    mufasaIframe.addEventListener('load', onLoad);
-
     const setPermissionValue = (value: boolean) => {
       mufasaIframe.contentWindow.postMessage(
         JSON.stringify({
@@ -151,7 +145,6 @@ const paymentForm = ({
     };
     const unbind = () => {
       window.removeEventListener('message', eventListener);
-      mufasaIframe.removeEventListener('load', onLoad);
     }
 
     return {

--- a/src/paymentForm.ts
+++ b/src/paymentForm.ts
@@ -52,7 +52,6 @@ const paymentForm = ({
     if(className) {
       mufasaIframe.className = className;
     }
-    container.appendChild(mufasaIframe);
 
     const eventListener = (event: MessageEvent) => {
       let eventData;
@@ -124,6 +123,8 @@ const paymentForm = ({
       }
     };
     listenPostMessages(eventListener);
+
+    container.appendChild(mufasaIframe);
 
     const setPermissionValue = (value: boolean) => {
       mufasaIframe.contentWindow.postMessage(

--- a/src/tests/iframePages/onLoad.html
+++ b/src/tests/iframePages/onLoad.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+  window.parent.postMessage(JSON.stringify({ action: 'Sequra.form_loaded' }), '*')
+</script>
+</body>
+</html>


### PR DESCRIPTION
### What is the goal?

Use the new `Sequra.form_loaded` post message to fire the onLoad callback instead of listening to the `onload` html event

### References
* **Related pull-requests:** https://github.com/sequra/checkout-form/pull/895, https://github.com/sequra/mufasa/pull/1427

### How is it being implemented?

Use the new `Sequra.form_loaded` post message to fire the onLoad callback instead of listening to the `onload` html event

### Opportunistic refactorings

No

### Caveats

The [Mufasa PR](https://github.com/sequra/mufasa/pull/1427) needs to be deployed first

### Does it affect (changes or update) any sensitive data?

_Check [Sensitive data list documentation](../blob/master/docs/sensitive_data/README.md) and [Sensitive data list](../blob/master/docs/sensitive_data/sensitive-data.yml)

### How is it tested?

Automatic tests

 ### How is it going to be distributed?

Standard distribution